### PR TITLE
Removal of master-slave vocabulary

### DIFF
--- a/config/views.py
+++ b/config/views.py
@@ -97,11 +97,11 @@ class ZoneDeployView(FormHelperMixin, base.TemplateResponseMixin, edit.FormMixin
 		files = []
 		warnings = []
 		for zone in models.Zone.objects.all():
-			slaves = []
+			subordinates = []
 			fedzone = None
 			try:
 				fedzone = federation.models.Zone.objects.get(name = zone.name)
-				slaves = fedzone.get_slaves()
+				subordinates = fedzone.get_subordinates()
 			except:
 				warnings.append("The zone {} is configured locally, but not configured in the federation.".format(zone.name))
 			
@@ -111,7 +111,7 @@ class ZoneDeployView(FormHelperMixin, base.TemplateResponseMixin, edit.FormMixin
 				'content': render_to_string('config/bind_zone.tpl', {
 					'basedir': settings.BIND_CONFIG_DIR,
 					'zone': zone,
-					'slaves': slaves,
+					'subordinates': subordinates,
 				}),
 				'include': True,
 			})
@@ -124,14 +124,14 @@ class ZoneDeployView(FormHelperMixin, base.TemplateResponseMixin, edit.FormMixin
 				'include': False,
 			})
 		
-		for zone in federation.models.Zone.get_slave_zones():
+		for zone in federation.models.Zone.get_subordinate_zones():
 			files.append({
 				'name': zone.name,
-				'filename': settings.BIND_CONFIG_DIR + 'slave_{}.conf'.format(zone.name),
-				'content': render_to_string('config/bind_slave_zone.tpl', {
+				'filename': settings.BIND_CONFIG_DIR + 'subordinate_{}.conf'.format(zone.name),
+				'content': render_to_string('config/bind_subordinate_zone.tpl', {
 					'basedir': settings.BIND_CONFIG_DIR,
 					'zone': zone,
-					'slaves': zone.get_slaves(),
+					'subordinates': zone.get_subordinates(),
 				}),
 				'include': True,
 			})

--- a/federation/migrations/0001_initial.py
+++ b/federation/migrations/0001_initial.py
@@ -53,10 +53,10 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=255, unique=True)),
                 ('enabled', models.BooleanField(default=True, verbose_name='Zone is enabled')),
-                ('slaves_all', models.BooleanField(default=True, verbose_name='All servers are slaves')),
-                ('master', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='zones_master', to='federation.Server', verbose_name='Master server')),
+                ('subordinates_all', models.BooleanField(default=True, verbose_name='All servers are subordinates')),
+                ('main', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='zones_main', to='federation.Server', verbose_name='Main server')),
                 ('owners', models.ManyToManyField(help_text='Users that are allowed to modify this object. Staff users can modify all objects.', related_name='owned_federation_zone', to=settings.AUTH_USER_MODEL, verbose_name='Owners')),
-                ('slaves', models.ManyToManyField(blank=True, related_name='zones_slave', to='federation.Server', verbose_name='Slave servers')),
+                ('subordinates', models.ManyToManyField(blank=True, related_name='zones_subordinate', to='federation.Server', verbose_name='Subordinate servers')),
             ],
             options={
                 'abstract': False,

--- a/federation/urls.py
+++ b/federation/urls.py
@@ -169,7 +169,7 @@ urlpatterns = [
 			CrispyCreateView.as_view(
 				model = models.Zone,
 				fields = [
-					'name', 'enabled', 'master', 'slaves_all', 'slaves'
+					'name', 'enabled', 'main', 'subordinates_all', 'subordinates'
 				],
 				form_submit_text = 'Submit',
 			)
@@ -187,7 +187,7 @@ urlpatterns = [
 			CrispyUpdateView.as_view(
 				model = models.Zone,
 				fields = [
-					'name', 'enabled', 'owners', 'master', 'slaves_all', 'slaves'
+					'name', 'enabled', 'owners', 'main', 'subordinates_all', 'subordinates'
 				],
 				form_submit_text = 'Submit',
 			)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.